### PR TITLE
fix: branch name in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   pull_request:
     branches:
-      - release-please--branches--master
+      - release-please--branches--main
     types: [closed]
 
 jobs:


### PR DESCRIPTION
`main` not `master` 🤦
