### PR TITLE
feat: restrict release workflow to release pr's

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && env.GITHUB_HEAD_REF == 'release-please--branches--main'
     steps:
     - name: Release Mock
       run: env
+


### PR DESCRIPTION
Take advantage of `GITHUB_HEAD_REF` environment variable to restrict
running releases to merged PR's from the standard Release Please branch
name `release-please--branches--main`.
