### PR TITLE
feat: make web listening port dynamic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ WORKDIR $WORKING_DIRECTORY
 
 COPY index.html $WORKING_DIRECTORY/
 
-CMD ["ruby", "-run", "-e", "httpd", ".", "-p", "8000"]
+CMD ruby -run -e httpd . -p $PORT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,5 @@ services:
       context: .
     ports:
       - "8000:8000"
+    environment:
+      PORT: 8000


### PR DESCRIPTION
Use an environment variable to specify the port the web server should
listen on. This will facilitate running the application on Heroku.
